### PR TITLE
#2809 Expand default mouseEnter delay to 0.5s

### DIFF
--- a/app/bitshares-ui-style-guide/Tooltip/index.js
+++ b/app/bitshares-ui-style-guide/Tooltip/index.js
@@ -9,10 +9,14 @@ class Tooltip extends Component {
     }
 
     render() {
+        let {mouseEnterDelay, ...remaining} = this.props;
+        if (mouseEnterDelay == undefined) {
+            mouseEnterDelay = this.defaultDelay;
+        }
         return (
             <AntTooltip
-                mouseEnterDelay={this.defaultDelay}
-                {...this.props}
+                mouseEnterDelay={mouseEnterDelay}
+                {...remaining}
             >
                 {this.props.children}
             </AntTooltip>

--- a/app/bitshares-ui-style-guide/Tooltip/index.js
+++ b/app/bitshares-ui-style-guide/Tooltip/index.js
@@ -1,3 +1,23 @@
-import {Tooltip} from "antd";
+import React, {Component} from "react";
+import {Tooltip as AntTooltip} from "antd";
+
+class Tooltip extends Component {
+
+    constructor(){
+        super();
+        this.defaultDelay = 0.5;
+    }
+
+    render() {
+        return (
+            <AntTooltip
+                mouseEnterDelay={this.defaultDelay}
+                {...this.props}
+            >
+                {this.props.children}
+            </AntTooltip>
+        );
+    }
+}
 
 export default Tooltip;


### PR DESCRIPTION
closes #11, #2809

Add default delay 0.5s for tooltips. Default delay would be omitted if `mouseEnterDelay` prop was passed in. 

Old behavior:
![TooltipsOldBehavior](https://user-images.githubusercontent.com/43940398/63358895-6f279b00-c374-11e9-8496-f4ba38cb27e6.gif)


New behavior : 
![AwesomeScreenshot-2019-8-20-1566312530663](https://user-images.githubusercontent.com/43940398/63358748-3b4c7580-c374-11e9-8558-14543af26f9d.gif)
